### PR TITLE
Fixed The Netherlands

### DIFF
--- a/Europe/netherlands.md
+++ b/Europe/netherlands.md
@@ -14,4 +14,4 @@
 - 8th March - 09:45pm - Jason McCreary
 - 8th March - 10:45pm - Matt Stauffer
 - 8th March - 11:45pm - Closing remarks
-- 8th March - 00:00am - Mingle in Slack
+- 9th March - 00:00am - Mingle in Slack

--- a/README.md
+++ b/README.md
@@ -6,5 +6,5 @@ As listed above this repo contains the markdown files with the country name as t
 
 - [India](https://github.com/introwit/laracon-online-schedule/blob/master/Asia/india.md)
 - [USA](https://github.com/introwit/laracon-online-schedule/blob/master/NorthAmerica/usa.md)
-- [Netherland](https://github.com/introwit/laracon-online-schedule/blob/master/Europe/netherland.md) (Credits to Herman's [tweet](https://twitter.com/HermanOstendorf/status/836961061907664896))
+- [Netherlands](https://github.com/introwit/laracon-online-schedule/blob/master/Europe/netherlands.md) (Credits to Herman's [tweet](https://twitter.com/HermanOstendorf/status/836961061907664896))
 - [Britain](https://github.com/introwit/laracon-online-schedule/blob/master/Europe/britain.md) (Credits to Dominic's [tweet](https://twitter.com/haakym/status/836941063524925440))


### PR DESCRIPTION
Changed netherland.md to netherlands.md
Changed 00:00am to March 9th