### PR TITLE
Converted to Maldives timezone.

### DIFF
--- a/Asia/maldives.md
+++ b/Asia/maldives.md
@@ -1,0 +1,15 @@
+- 8th March - 6:00 pm - Mingle in Slack
+- 8th March - 6:45 pm - Opening remarks
+- 8th March - 7:00 pm - Jeffrey Way
+- 8th March - 8:00 pm - Evan You
+- 8th March - 9:00 pm - Break & Mingle in Slack
+- 8th March - 9:15 pm - Rachel Andrew
+- 8th March - 10:15 pm - Adam Wathan
+- 8th March - 11:15 pm - Break & Mingle in Slack
+- 8th March - 11:30 pm - Taylor Otwell
+- 9th March - 12:30 am - Nick Canzoneri
+- 9th March - 1:30 am - Break & Mingle in Slack
+- 9th March - 1:45 am - Jason McCreary
+- 9th March - 2:45 am - Matt Stauffer
+- 9th March - 3:45 am - Closing remarks
+- 9th March - 4:00 am - Mingle in Slack

--- a/README.md
+++ b/README.md
@@ -8,3 +8,4 @@ As listed above this repo contains the markdown files with the country name as t
 - [USA](https://github.com/introwit/laracon-online-schedule/blob/master/NorthAmerica/usa.md)
 - [Netherland](https://github.com/introwit/laracon-online-schedule/blob/master/Europe/netherland.md) (Credits to Herman's [tweet](https://twitter.com/HermanOstendorf/status/836961061907664896))
 - [Britain](https://github.com/introwit/laracon-online-schedule/blob/master/Europe/britain.md) (Credits to Dominic's [tweet](https://twitter.com/haakym/status/836941063524925440))
+- [Maldives](https://github.com/ahmedmaazin/laracon-online-schedule/blob/master/Asia/maldives.md)


### PR DESCRIPTION
Converted to Maldives time zone. Used default timezone as `America/New_York`.